### PR TITLE
Enable port configuration via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,6 @@ DOCKER_USERNAME=your-dockerhub-username
 DOCKER_PASSWORD=your-dockerhub-password
 DOCKER_REPO=your-dockerhub-username/your-app-name
 
-# Optional: Custom container port mapping
+# Optional: Custom port mapping for container
+HOST_PORT=3000
 CONTAINER_PORT=3000

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Chỉnh sửa file `.env`:
 ```env
 # Server Configuration
 PORT=3000
+HOST_PORT=3000
+CONTAINER_PORT=3000
 
 # GitHub Webhook Configuration
 WEBHOOK_SECRET=your-github-webhook-secret
@@ -47,6 +49,10 @@ DOCKER_USERNAME=your-dockerhub-username
 DOCKER_PASSWORD=your-dockerhub-password
 DOCKER_REPO=your-dockerhub-username/your-app-name
 ```
+
+- `PORT`: cổng webhook server lắng nghe
+- `HOST_PORT`: cổng trên máy host ánh xạ tới container
+- `CONTAINER_PORT`: cổng ứng dụng chạy bên trong container
 
 ### 3. Cài đặt dependencies
 
@@ -67,7 +73,7 @@ npm start
 ## Cấu hình GitHub Webhook
 
 1. Vào GitHub repository → Settings → Webhooks
-2. Add webhook với URL: `http://your-server:3000/webhook`
+2. Add webhook với URL: `http://your-server:${PORT}/webhook`
 3. Content type: `application/json`
 4. Secret: Giống với `WEBHOOK_SECRET` trong `.env`
 5. Events: Chọn "Create" (for tags)

--- a/server.js
+++ b/server.js
@@ -6,6 +6,8 @@ const path = require('path');
 const fs = require('fs');
 const app = express();
 const PORT = process.env.PORT || 3000;
+const HOST_PORT = process.env.HOST_PORT || 3000;
+const CONTAINER_PORT = process.env.CONTAINER_PORT || 3000;
 
 // Middleware để parse JSON
 app.use(express.json());
@@ -197,8 +199,10 @@ async function runCIProcess(tagName) {
       console.log('No existing container to stop');
     }
     
-    // Run new container
-    await executeCommand(`docker run -d --name ${containerName} -p 3000:3000 ${imageName}`);
+    // Run new container with configurable ports
+    await executeCommand(
+      `docker run -d --name ${containerName} -p ${HOST_PORT}:${CONTAINER_PORT} -e PORT=${CONTAINER_PORT} ${imageName}`
+    );
     
     console.log('CI process completed successfully!');
     


### PR DESCRIPTION
## Summary
- allow configuring webhook server, host port, and container port through environment variables
- document port variables in `.env.example` and README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688dca98aaf483289cfb5049bf6cd2e4